### PR TITLE
feat(halo2_proofs): call msm_gpu using tachyon

### DIFF
--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -58,6 +58,8 @@ cfg-if = "0.1"
 poseidon = { git = "https://github.com/kroma-network/poseidon.git", rev = "00a2fe0" }
 num-integer = "0.1"
 num-bigint = { version = "0.4", features = ["rand"] }
+lazy_static = "1"
+stdint = "0.2.0"
 
 # Developer tooling dependencies
 plotters = { version = "0.3.0", optional = true }
@@ -67,12 +69,18 @@ log = "0.4.17"
 # timer
 ark-std = { version = "0.3.0" }
 
+# binding
+cxx = "1.0"
+
 [dev-dependencies]
 assert_matches = "1.5"
 criterion = "0.3"
 gumdrop = "0.8"
 proptest = "1"
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
+
+[build-dependencies]
+cxx-build = "1.0"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 getrandom = { version = "0.2", features = ["js"] }
@@ -87,6 +95,7 @@ shplonk = []
 gwc = []
 phase-check = []
 profile = ["ark-std/print-trace"]
+tachyon_msm_gpu = []
 
 [lib]
 bench = false

--- a/halo2_proofs/build.rs
+++ b/halo2_proofs/build.rs
@@ -1,0 +1,24 @@
+fn main() {
+    cxx_build::bridge("src/lib.rs")
+        .files([
+            "src/msm.cc",
+            #[cfg(feature = "tachyon_msm_gpu")]
+            "src/msm_gpu.cc",
+        ])
+        .flag_if_supported("-std=c++17")
+        .compile("halo2_proofs");
+
+    let dep_files = vec![
+        "src/lib.rs",
+        "src/msm.cc",
+        #[cfg(feature = "tachyon_msm_gpu")]
+        "src/msm_gpu.cc",
+        "include/msm.h",
+        "include/msm_gpu.h",
+    ];
+    for file in dep_files {
+        println!("cargo:rerun-if-changed={file}");
+    }
+
+    println!("cargo:rustc-link-lib=dylib=tachyon");
+}

--- a/halo2_proofs/include/msm.h
+++ b/halo2_proofs/include/msm.h
@@ -1,0 +1,25 @@
+#ifndef HALO2_PROOFS_INCLUDE_MSM_H_
+#define HALO2_PROOFS_INCLUDE_MSM_H_
+
+#include "rust/cxx.h"
+
+namespace tachyon {
+namespace halo2 {
+
+struct G1MSM;
+
+struct G1Point2;
+struct G1JacobianPoint;
+struct Fr;
+
+rust::Box<G1MSM> create_g1_msm(uint8_t degree);
+
+void destroy_g1_msm(rust::Box<G1MSM> msm);
+
+rust::Box<G1JacobianPoint> g1_msm(G1MSM* msm, rust::Slice<const G1Point2> bases,
+                                  rust::Slice<const Fr> scalars);
+
+}  // namespace halo2
+}  // namespace tachyon
+
+#endif  // HALO2_PROOFS_INCLUDE_MSM_H_

--- a/halo2_proofs/include/msm_gpu.h
+++ b/halo2_proofs/include/msm_gpu.h
@@ -1,0 +1,26 @@
+#ifndef HALO2_PROOFS_INCLUDE_MSM_GPU_H_
+#define HALO2_PROOFS_INCLUDE_MSM_GPU_H_
+
+#include "rust/cxx.h"
+
+namespace tachyon {
+namespace halo2 {
+
+struct G1MSMGpu;
+
+struct G1Point2;
+struct G1JacobianPoint;
+struct Fr;
+
+rust::Box<G1MSMGpu> create_g1_msm_gpu(uint8_t degree, int algorithm);
+
+void destroy_g1_msm_gpu(rust::Box<G1MSMGpu> msm);
+
+rust::Box<G1JacobianPoint> g1_msm_gpu(G1MSMGpu* msm,
+                                      rust::Slice<const G1Point2> bases,
+                                      rust::Slice<const Fr> scalars);
+
+}  // namespace halo2
+}  // namespace tachyon
+
+#endif  // HALO2_PROOFS_INCLUDE_MSM_GPU_H_

--- a/halo2_proofs/src/lib.rs
+++ b/halo2_proofs/src/lib.rs
@@ -19,7 +19,7 @@
 )]
 #![deny(broken_intra_doc_links)]
 #![deny(missing_debug_implementations)]
-#![deny(unsafe_code)]
+#![allow(unsafe_code)]
 // Remove this once we update pasta_curves
 #![allow(unused_imports)]
 #![allow(clippy::derive_partial_eq_without_eq)]
@@ -35,3 +35,74 @@ pub mod transcript;
 pub mod dev;
 mod helpers;
 pub use helpers::SerdeFormat;
+
+#[cxx::bridge(namespace = "tachyon::halo2")]
+pub mod ffi {
+    // Rust types and signatures exposed to C++.
+    extern "Rust" {
+        type G1MSM;
+        type G1MSMGpu;
+        type G1Point2;
+        type G1JacobianPoint;
+        type Fq;
+        type Fr;
+    }
+
+    // C++ types and signatures exposed to Rust.
+    unsafe extern "C++" {
+        include!("halo2_proofs/include/msm.h");
+        include!("halo2_proofs/include/msm_gpu.h");
+
+        fn create_g1_msm(degree: u8) -> Box<G1MSM>;
+        fn destroy_g1_msm(msm: Box<G1MSM>);
+        unsafe fn g1_msm(
+            msm: *mut G1MSM,
+            bases: &[G1Point2],
+            scalars: &[Fr],
+        ) -> Box<G1JacobianPoint>;
+        #[cfg(feature = "tachyon_msm_gpu")]
+        fn create_g1_msm_gpu(degree: u8, algorithm: i32) -> Box<G1MSMGpu>;
+        #[cfg(feature = "tachyon_msm_gpu")]
+        fn destroy_g1_msm_gpu(msm: Box<G1MSMGpu>);
+        #[cfg(feature = "tachyon_msm_gpu")]
+        unsafe fn g1_msm_gpu(
+            msm: *mut G1MSMGpu,
+            bases: &[G1Point2],
+            scalars: &[Fr],
+        ) -> Box<G1JacobianPoint>;
+    }
+}
+
+#[derive(Debug)]
+pub struct G1MSM;
+
+#[derive(Debug)]
+pub struct G1MSMGpu;
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct G1Point2 {
+    pub x: Fq,
+    pub y: Fq,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct G1JacobianPoint {
+    pub x: Fq,
+    pub y: Fq,
+    pub z: Fq,
+}
+
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct Fq(pub [u64; 4]);
+
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct Fr(pub [u64; 4]);
+
+lazy_static::lazy_static! {
+    pub static ref MSM_GPU: std::sync::Mutex<stdint::uintptr_t> =
+        std::sync::Mutex::new(0);
+}

--- a/halo2_proofs/src/msm.cc
+++ b/halo2_proofs/src/msm.cc
@@ -1,0 +1,30 @@
+#include "halo2_proofs/include/msm.h"
+
+#include <tachyon/c/math/elliptic_curves/bn/bn254/msm.h>
+
+#include "halo2_proofs/src/lib.rs.h"
+
+namespace tachyon::halo2 {
+
+rust::Box<G1MSM> create_g1_msm(uint8_t degree) {
+  return rust::Box<G1MSM>::from_raw(
+      reinterpret_cast<G1MSM*>(tachyon_bn254_g1_create_msm(degree)));
+}
+
+void destroy_g1_msm(rust::Box<G1MSM> msm) {
+  tachyon_bn254_g1_destroy_msm(
+      reinterpret_cast<tachyon_bn254_g1_msm_ptr>(msm.into_raw()));
+}
+
+rust::Box<G1JacobianPoint> g1_msm(G1MSM* msm, rust::Slice<const G1Point2> bases,
+                                  rust::Slice<const Fr> scalars) {
+  auto ret = tachyon_bn254_g1_point2_msm(
+      reinterpret_cast<tachyon_bn254_g1_msm_ptr>(msm),
+      reinterpret_cast<const tachyon_bn254_g1_point2*>(bases.data()),
+      reinterpret_cast<const tachyon_bn254_fr*>(scalars.data()),
+      scalars.length());
+  return rust::Box<G1JacobianPoint>::from_raw(
+      reinterpret_cast<G1JacobianPoint*>(ret));
+}
+
+}  // namespace tachyon::halo2

--- a/halo2_proofs/src/msm_gpu.cc
+++ b/halo2_proofs/src/msm_gpu.cc
@@ -1,0 +1,31 @@
+#include "halo2_proofs/include/msm_gpu.h"
+
+#include <tachyon/c/math/elliptic_curves/bn/bn254/msm_gpu.h>
+
+#include "halo2_proofs/src/lib.rs.h"
+
+namespace tachyon::halo2 {
+
+rust::Box<G1MSMGpu> create_g1_msm_gpu(uint8_t degree, int algorithm) {
+  return rust::Box<G1MSMGpu>::from_raw(reinterpret_cast<G1MSMGpu*>(
+      tachyon_bn254_g1_create_msm_gpu(degree, algorithm)));
+}
+
+void destroy_g1_msm_gpu(rust::Box<G1MSMGpu> msm) {
+  tachyon_bn254_g1_destroy_msm_gpu(
+      reinterpret_cast<tachyon_bn254_g1_msm_gpu_ptr>(msm.into_raw()));
+}
+
+rust::Box<G1JacobianPoint> g1_msm_gpu(G1MSMGpu* msm,
+                                      rust::Slice<const G1Point2> bases,
+                                      rust::Slice<const Fr> scalars) {
+  auto ret = tachyon_bn254_g1_point2_msm_gpu(
+      reinterpret_cast<tachyon_bn254_g1_msm_gpu_ptr>(msm),
+      reinterpret_cast<const tachyon_bn254_g1_point2*>(bases.data()),
+      reinterpret_cast<const tachyon_bn254_fr*>(scalars.data()),
+      scalars.length());
+  return rust::Box<G1JacobianPoint>::from_raw(
+      reinterpret_cast<G1JacobianPoint*>(ret));
+}
+
+}  // namespace tachyon::halo2

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -47,7 +47,7 @@ pub fn create_proof<
     T: TranscriptWrite<Scheme::Curve, E>,
     ConcreteCircuit: Circuit<Scheme::Scalar>,
 >(
-    params: &'params Scheme::ParamsProver,
+    params: &'params mut Scheme::ParamsProver,
     pk: &ProvingKey<Scheme::Curve>,
     circuits: &[ConcreteCircuit],
     instances: &[&[&[Scheme::Scalar]]],
@@ -432,6 +432,7 @@ pub fn create_proof<
     // Sample theta challenge for keeping lookup columns linearly independent
     let theta: ChallengeTheta<_> = transcript.squeeze_challenge_scalar();
 
+    params.set_maybe_non_uniform(true);
     let lookups: Vec<Vec<lookup::prover::Permuted<Scheme::Curve>>> = instance
         .iter()
         .zip(advice.iter())
@@ -520,6 +521,7 @@ pub fn create_proof<
             },
         )
         .collect();
+    params.set_maybe_non_uniform(false);
 
     // Evaluate the h(X) polynomial
     let h_poly = pk.ev.evaluate_h(

--- a/halo2_proofs/src/poly/commitment.rs
+++ b/halo2_proofs/src/poly/commitment.rs
@@ -45,6 +45,8 @@ pub trait Params<'params, C: CurveAffine>: Sized + Clone {
     /// Multi scalar multiplication engine
     type MSM: MSM<C> + 'params;
 
+    fn set_maybe_non_uniform(&mut self, value: bool);
+
     /// Logaritmic size of the circuit
     fn k(&self) -> u32;
 

--- a/halo2_proofs/src/poly/ipa/commitment.rs
+++ b/halo2_proofs/src/poly/ipa/commitment.rs
@@ -65,6 +65,8 @@ impl<'params, C: CurveAffine> ParamsVerifier<'params, C> for ParamsIPA<C> {}
 impl<'params, C: CurveAffine> Params<'params, C> for ParamsIPA<C> {
     type MSM = MSMIPA<'params, C>;
 
+    fn set_maybe_non_uniform(&mut self, value: bool) {}
+
     fn k(&self) -> u32 {
         self.k
     }

--- a/halo2_proofs/src/poly/kzg/msm.rs
+++ b/halo2_proofs/src/poly/kzg/msm.rs
@@ -5,6 +5,7 @@ use crate::{
     arithmetic::{best_multiexp, parallelize, CurveAffine},
     poly::commitment::MSM,
 };
+use ff::Field;
 use group::{Curve, Group};
 use halo2curves::pairing::{Engine, MillerLoopResult, MultiMillerLoop};
 
@@ -13,6 +14,7 @@ use halo2curves::pairing::{Engine, MillerLoopResult, MultiMillerLoop};
 pub struct MSMKZG<E: Engine> {
     pub(crate) scalars: Vec<E::Scalar>,
     pub(crate) bases: Vec<E::G1>,
+    pub(crate) maybe_non_uniform: bool,
 }
 
 impl<E: Engine> MSMKZG<E> {
@@ -21,6 +23,7 @@ impl<E: Engine> MSMKZG<E> {
         MSMKZG {
             scalars: vec![],
             bases: vec![],
+            maybe_non_uniform: false,
         }
     }
 
@@ -66,6 +69,26 @@ impl<E: Engine + Debug> MSM<E::G1Affine> for MSMKZG<E> {
         use group::prime::PrimeCurveAffine;
         let mut bases = vec![E::G1Affine::identity(); self.scalars.len()];
         E::G1::batch_normalize(&self.bases, &mut bases);
+        #[cfg(feature = "tachyon_msm_gpu")]
+        let use_gpu = !self.maybe_non_uniform;
+        #[cfg(feature = "tachyon_msm_gpu")]
+        let ret = if use_gpu {
+            use crate::{ffi, Fr as CppFr, G1MSMGpu, G1Point2 as CppG1Point2, MSM_GPU};
+            use std::mem;
+
+            unsafe {
+                let bases: &[CppG1Point2] = mem::transmute(bases.as_slice());
+                let scalars: &[CppFr] = mem::transmute(self.scalars.as_slice());
+
+                let msm = *MSM_GPU.lock().unwrap() as *mut G1MSMGpu;
+                let ret = ffi::g1_msm_gpu(msm, bases, scalars);
+                let ret: Box<E::G1> = mem::transmute(ret);
+                *ret
+            }
+        } else {
+            best_multiexp(&self.scalars, &bases)
+        };
+        #[cfg(not(feature = "tachyon_msm_gpu"))]
         best_multiexp(&self.scalars, &bases)
     }
 
@@ -103,6 +126,7 @@ impl<E: Engine + Debug> PreMSM<E> {
         MSMKZG {
             scalars: scalars.into_iter().flatten().collect(),
             bases: bases.into_iter().flatten().collect(),
+            maybe_non_uniform: false,
         }
     }
 


### PR DESCRIPTION
# Description

This replaces some of msm operations with gpu operation implemented in tachyon. Since gpu operations gets really slow when the input scalars are not randomly distributed, and this usually happens after advice assignment stage. We mark those stages with `maybe_non_uniform()`. 

When taking a look at https://zcash.github.io/halo2/design/proving-system.html, those ranges only includes committing `Adivce Columns`.