### PR TITLE
feat: update tachyon c api

### DIFF
--- a/halo2_proofs/include/bn254_gwc_prover.h
+++ b/halo2_proofs/include/bn254_gwc_prover.h
@@ -13,6 +13,7 @@ namespace tachyon::halo2_api::bn254 {
 
 struct Fr;
 struct G1JacobianPoint;
+struct G2AffinePoint;
 struct InstanceSingle;
 struct AdviceSingle;
 class ProvingKey;
@@ -23,6 +24,8 @@ class Poly;
 class GWCProver {
  public:
   GWCProver(uint8_t transcript_type, uint32_t k, const Fr& s);
+  GWCProver(uint8_t transcript_type, uint32_t k, const uint8_t* params,
+            size_t params_len);
   GWCProver(const GWCProver& other) = delete;
   GWCProver& operator=(const GWCProver& other) = delete;
   ~GWCProver();
@@ -31,6 +34,7 @@ class GWCProver {
 
   uint32_t k() const;
   uint64_t n() const;
+  rust::Box<G2AffinePoint> s_g2() const;
   rust::Box<G1JacobianPoint> commit(const Poly& poly) const;
   rust::Box<G1JacobianPoint> commit_lagrange(const Evals& evals) const;
   std::unique_ptr<Evals> empty_evals() const;
@@ -54,6 +58,9 @@ class GWCProver {
 
 std::unique_ptr<GWCProver> new_gwc_prover(uint8_t transcript_type, uint32_t k,
                                           const Fr& s);
+
+std::unique_ptr<GWCProver> new_gwc_prover_from_params(
+    uint8_t transcript_type, uint32_t k, rust::Slice<const uint8_t> params);
 
 }  // namespace tachyon::halo2_api::bn254
 

--- a/halo2_proofs/include/bn254_shplonk_prover.h
+++ b/halo2_proofs/include/bn254_shplonk_prover.h
@@ -13,6 +13,7 @@ namespace tachyon::halo2_api::bn254 {
 
 struct Fr;
 struct G1JacobianPoint;
+struct G2AffinePoint;
 struct InstanceSingle;
 struct AdviceSingle;
 class ProvingKey;
@@ -23,6 +24,8 @@ class Poly;
 class SHPlonkProver {
  public:
   SHPlonkProver(uint8_t transcript_type, uint32_t k, const Fr& s);
+  SHPlonkProver(uint8_t transcript_type, uint32_t k, const uint8_t* params,
+                size_t params_len);
   SHPlonkProver(const SHPlonkProver& other) = delete;
   SHPlonkProver& operator=(const SHPlonkProver& other) = delete;
   ~SHPlonkProver();
@@ -31,6 +34,7 @@ class SHPlonkProver {
 
   uint32_t k() const;
   uint64_t n() const;
+  rust::Box<G2AffinePoint> s_g2() const;
   rust::Box<G1JacobianPoint> commit(const Poly& poly) const;
   rust::Box<G1JacobianPoint> commit_lagrange(const Evals& evals) const;
   std::unique_ptr<Evals> empty_evals() const;
@@ -54,6 +58,9 @@ class SHPlonkProver {
 
 std::unique_ptr<SHPlonkProver> new_shplonk_prover(uint8_t transcript_type,
                                                   uint32_t k, const Fr& s);
+
+std::unique_ptr<SHPlonkProver> new_shplonk_prover_from_params(
+    uint8_t transcript_type, uint32_t k, rust::Slice<const uint8_t> params);
 
 }  // namespace tachyon::halo2_api::bn254
 

--- a/halo2_proofs/src/bn254_gwc_prover.cc
+++ b/halo2_proofs/src/bn254_gwc_prover.cc
@@ -11,6 +11,11 @@ GWCProver::GWCProver(uint8_t transcript_type, uint32_t k, const Fr& s)
     : prover_(tachyon_halo2_bn254_gwc_prover_create_from_unsafe_setup(
           transcript_type, k, reinterpret_cast<const tachyon_bn254_fr*>(&s))) {}
 
+GWCProver::GWCProver(uint8_t transcript_type, uint32_t k, const uint8_t* params,
+                     size_t params_len)
+    : prover_(tachyon_halo2_bn254_gwc_prover_create_from_params(
+          transcript_type, k, params, params_len)) {}
+
 GWCProver::~GWCProver() { tachyon_halo2_bn254_gwc_prover_destroy(prover_); }
 
 uint32_t GWCProver::k() const {
@@ -19,6 +24,12 @@ uint32_t GWCProver::k() const {
 
 uint64_t GWCProver::n() const {
   return static_cast<uint64_t>(tachyon_halo2_bn254_gwc_prover_get_n(prover_));
+}
+
+rust::Box<G2AffinePoint> GWCProver::s_g2() const {
+  return rust::Box<G2AffinePoint>::from_raw(
+      reinterpret_cast<G2AffinePoint*>(new tachyon_bn254_g2_affine(
+          *tachyon_halo2_bn254_gwc_prover_get_s_g2(prover_))));
 }
 
 rust::Box<G1JacobianPoint> GWCProver::commit(const Poly& poly) const {
@@ -178,6 +189,12 @@ rust::Vec<uint8_t> GWCProver::get_proof() const {
 std::unique_ptr<GWCProver> new_gwc_prover(uint8_t transcript_type, uint32_t k,
                                           const Fr& s) {
   return std::make_unique<GWCProver>(transcript_type, k, s);
+}
+
+std::unique_ptr<GWCProver> new_gwc_prover_from_params(
+    uint8_t transcript_type, uint32_t k, rust::Slice<const uint8_t> params) {
+  return std::make_unique<GWCProver>(transcript_type, k, params.data(),
+                                     params.size());
 }
 
 rust::Box<Fr> ProvingKey::transcript_repr_gwc(const GWCProver& prover) {


### PR DESCRIPTION
In this PR, `from_params()` and `s_g2()` method was added to `TachyonGWCProver` and `TachyonSHPlonkProver`.

See related [PR on Tachyon](https://github.com/kroma-network/tachyon/pull/355)